### PR TITLE
rails 5 support

### DIFF
--- a/lib/auto_migrations.rb
+++ b/lib/auto_migrations.rb
@@ -45,7 +45,8 @@ module AutoMigrations
     class << base
       cattr_accessor :tables_in_schema, :indexes_in_schema
       self.tables_in_schema, self.indexes_in_schema = [], []
-      alias_method_chain :method_missing, :auto_migration
+      alias_method :method_missing_without_auto_migration, :method_missing
+      alias_method :method_missing, :method_missing_with_auto_migration
     end
   end
 


### PR DESCRIPTION
otherwise it would cause warnings  saying

- DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.

- DEPRECATION WARNING: #tables currently returns both tables and views.
This behavior is deprecated and will be changed with Rails 5.1 to only
return tables. Use #data_sources instead.

